### PR TITLE
Bump application version to 1.0.1, update Dockerfile, and enhance CI …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,23 +6,18 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  JAVA_VERSION: '21'
-  DOCKER_REGISTRY: ghcr.io
-  DOCKER_IMAGE_NAME: your-org/your-app-name
-
 jobs:
   setup:
     name: ☕ Set up Java
     runs-on: ubuntu-latest
     outputs:
-      java-version: ${{ env.JAVA_VERSION }}
+      java-version: ${{ secrets.JAVA_VERSION }}
     steps:
-      - name: Set up Java ${{ env.JAVA_VERSION }}
+      - name: Set up Java ${{ secrets.JAVA_VERSION }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: ${{ env.JAVA_VERSION }}
+          java-version: ${{ secrets.JAVA_VERSION }}
 
   checkout-and-cache:
     name: Checkout & Cache
@@ -50,9 +45,9 @@ jobs:
       - name: 🧾 Checkout code
         uses: actions/checkout@v3
       - name: ✅ Run Tests
-        run: ./gradlew test --no-daemon
+        run: ./gradlew test
       - name: 🔧 Build Project
-        run: ./gradlew clean build --no-daemon
+        run: ./gradlew clean build
 
 
   docker:
@@ -75,9 +70,9 @@ jobs:
       - name: 🔐 Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: 🐳 Build Docker Image
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.immortals'
-version = '1.0.0'
+version = '1.0.1'
 
 java {
     toolchain {

--- a/dockerfile
+++ b/dockerfile
@@ -39,7 +39,7 @@ WORKDIR ${APP_HOME}
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 # Copy JAR from build stage
-COPY --from=build /app/build/libs/mini-url-1.0.0.jar mini-url.jar
+COPY --from=build /app/build/libs/mini-url-1.0.1.jar mini-url.jar
 
 # Set ownership and permissions
 RUN chown appuser:appgroup mini-url.jar


### PR DESCRIPTION
Bump application version to 1.0.1, update Dockerfile, and enhance CI workflow

Updated the application version in `build.gradle` and Dockerfile to `1.0.1`. Enhanced CI workflow by switching from environment variables to GitHub secrets for improved security, simplified Gradle commands, and streamlined Docker registry login configurations..